### PR TITLE
[#13][Hotfix] Hide sponsor blocks

### DIFF
--- a/_sass/_sponsors.scss
+++ b/_sass/_sponsors.scss
@@ -4,7 +4,8 @@ $c-red: #ff0000;
 
 
 @mixin sponsor-block($width, $height) {
-  display: none;
+  // Remove important on integration ADV
+  display: none !important;
   width: $width;
   height: $height;
 


### PR DESCRIPTION
Issue: [#13]

Description:

Close red empty blocks

Testing steps:

Red blocks are hidden

Checklist:

- [x] Spec tests are passing on CI
- [x] `rake lint` does not return any warnings
- [x] Tested manually
